### PR TITLE
Add deque as a supported state type

### DIFF
--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -8,9 +8,11 @@
 # pyre-ignore-all-errors[56]: Pyre was not able to infer the type of argument
 
 import unittest
+from collections import deque
 
 import torch
 from torcheval.utils.test_utils.dummy_metric import (
+    DummySumDequeStateMetric,
     DummySumDictStateMetric,
     DummySumListStateMetric,
     DummySumMetric,
@@ -79,6 +81,34 @@ class MetricBaseClassTest(unittest.TestCase):
                 "doc4": torch.tensor(0.0),
             },
         )
+
+    def test_add_state_tensor_deque(self) -> None:
+        metric = DummySumDequeStateMetric()
+        metric._add_state("x1", deque())
+        assert isinstance(metric.x1, deque)
+        torch.testing.assert_close(metric.x1, deque())
+
+        metric._add_state("x2", deque([torch.tensor(0.0), torch.tensor(1.0)]))
+        assert isinstance(metric.x2, deque)
+        torch.testing.assert_close(
+            metric.x2, deque([torch.tensor(0.0), torch.tensor(1.0)])
+        )
+
+        tensor_deque = deque([torch.tensor(0.0)])
+        metric._add_state("x3", tensor_deque)
+        assert isinstance(metric.x3, deque)
+        torch.testing.assert_close(metric.x3, tensor_deque)
+        tensor_deque.append(torch.tensor(1.0))
+        self.assertNotEqual(metric.x3, tensor_deque)
+        assert isinstance(metric.x3, deque)
+        torch.testing.assert_close(metric.x3, deque([torch.tensor(0.0)]))
+
+        tensor_deque = metric.x3
+        tensor_deque.append(torch.tensor(1.0))
+        tensor_deque.popleft()
+        metric._add_state("x4", tensor_deque)
+        assert isinstance(metric.x4, deque)
+        torch.testing.assert_close(metric.x4, deque([torch.tensor(1.0)]))
 
     def test_add_state_invalid(self) -> None:
         metric = DummySumMetric()
@@ -171,6 +201,38 @@ class MetricBaseClassTest(unittest.TestCase):
             metric.x, {"doc1": torch.tensor(0.0), "doc2": torch.tensor(1.0)}
         )
 
+    def test_reset_state_tensor_deque(self) -> None:
+        metric = DummySumDequeStateMetric()
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque())
+        metric.update(torch.tensor(1.0))
+        metric.update(torch.tensor(2.0))
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(
+            metric.x, deque([torch.tensor(1.0), torch.tensor(2.0)])
+        )
+
+        # reset once
+        metric.reset()
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque())
+        metric.update(torch.tensor(1.0))
+        metric.update(torch.tensor(2.0))
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(
+            metric.x, deque([torch.tensor(1.0), torch.tensor(2.0)])
+        )
+
+        # reset again
+        metric.reset()
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque())
+
+        # update and reset chained
+        metric.update(torch.tensor(1.0)).reset().update(torch.tensor(2.0))
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque([torch.tensor(2.0)]))
+
     def test_save_load_state_dict_state_tensor(self) -> None:
         metric = DummySumMetric()
         self.assertDictEqual(metric.state_dict(), {"sum": torch.tensor(0.0)})
@@ -253,6 +315,37 @@ class MetricBaseClassTest(unittest.TestCase):
         self.assertDictEqual(
             another_loaded_metric.state_dict(),
             {"x": {"doc1": torch.tensor(1.0), "doc2": torch.tensor(2.0)}},
+        )
+
+    def test_save_load_state_dict_state_tensor_deque(self) -> None:
+        metric = DummySumDequeStateMetric()
+        self.assertDictEqual(metric.state_dict(), {"x": deque()})
+        metric.update(torch.tensor(1.0))
+        metric.update(torch.tensor(2.0))
+        self.assertDictEqual(
+            metric.state_dict(), {"x": deque([torch.tensor(1.0), torch.tensor(2.0)])}
+        )
+
+        state_dict = metric.state_dict()
+        loaded_metric = DummySumDequeStateMetric()
+        loaded_metric.load_state_dict(state_dict)
+        self.assertDictEqual(
+            loaded_metric.state_dict(),
+            {"x": deque([torch.tensor(1.0), torch.tensor(2.0)])},
+        )
+        torch.testing.assert_close(
+            loaded_metric.update(torch.tensor(-1.0)).compute(), torch.tensor(2.0)
+        )
+        self.assertDictEqual(
+            loaded_metric.state_dict(),
+            {"x": deque([torch.tensor(1.0), torch.tensor(2.0), torch.tensor(-1.0)])},
+        )
+
+        another_loaded_metric = DummySumDequeStateMetric()
+        another_loaded_metric.load_state_dict(state_dict)
+        self.assertDictEqual(
+            another_loaded_metric.state_dict(),
+            {"x": deque([torch.tensor(1.0), torch.tensor(2.0)])},
         )
 
     def test_state_dict_destination_prefix_wrong_state_value(self) -> None:
@@ -347,6 +440,22 @@ class MetricBaseClassTest(unittest.TestCase):
         torch.testing.assert_close(metric.x, {"doc1": torch.tensor(1.0, device="cpu")})
         metric.to("cuda")
         torch.testing.assert_close(metric.x, {"doc1": torch.tensor(1.0, device="cuda")})
+
+    @unittest.skipUnless(
+        condition=torch.cuda.is_available(), reason="This test needs a GPU host to run."
+    )
+    def test_to_device_state_tensor_deque(self) -> None:
+        metric = DummySumDequeStateMetric().to("cuda")
+        metric.update(torch.tensor(1.0).to("cuda")).compute()
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque([torch.tensor(1.0, device="cuda")]))
+
+        metric.to("cpu")
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque([torch.tensor(1.0, device="cpu")]))
+        metric.to("cuda")
+        assert isinstance(metric.x, deque)
+        torch.testing.assert_close(metric.x, deque([torch.tensor(1.0, device="cuda")]))
 
     def test_to_device_invalid_state(self) -> None:
         metric = DummySumMetric()

--- a/torcheval/utils/test_utils/dummy_metric.py
+++ b/torcheval/utils/test_utils/dummy_metric.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import Iterable, TypeVar
 
 import torch
@@ -99,4 +99,34 @@ class DummySumDictStateMetric(Metric[torch.Tensor]):
             for k in metric.keys():
                 self.x[k] += metric.x[k].to(self.device)
 
+        return self
+
+
+TDummySumDequeStateMetric = TypeVar("TDummySumDequeStateMetric")
+
+
+class DummySumDequeStateMetric(Metric[torch.Tensor]):
+    def __init__(self: TDummySumDequeStateMetric) -> None:
+        super().__init__()
+        self._add_state("x", deque())
+
+    @torch.inference_mode()
+    # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
+    def update(
+        self: TDummySumDequeStateMetric, x: torch.Tensor
+    ) -> TDummySumDequeStateMetric:
+        self.x.append(x)
+        return self
+
+    @torch.inference_mode()
+    def compute(self: TDummySumDequeStateMetric) -> torch.Tensor:
+        # pyre-fixme[7]: Expected `Tensor` but got `int`.
+        return sum(tensor.sum() for tensor in self.x)
+
+    @torch.inference_mode()
+    def merge_state(
+        self: TDummySumDequeStateMetric, metrics: Iterable[TDummySumDequeStateMetric]
+    ) -> TDummySumDequeStateMetric:
+        for metric in metrics:
+            self.x.extend(element.to(self.device) for element in metric.x)
         return self


### PR DESCRIPTION
Summary:
We are going to add window version of each metric. Windowed metrics would append new data and pop old data from left when the buffer is full and exceed the window size.

Therefore, we add deque as a supported state type for window metric implementation.

Reviewed By: ananthsub, DuYicong515

Differential Revision: D38591082

