### PR TITLE
add device parameters to metric constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ device = torch.device(
     else "cpu"
 )
 
-metric = MulticlassAccuracy().to(device)
+metric = MulticlassAccuracy(device=device)
 num_epochs, num_batches = 4, 8
 
 for epoch in range(num_epochs):

--- a/examples/distributed_example.py
+++ b/examples/distributed_example.py
@@ -71,8 +71,8 @@ def train() -> None:
     train_dataloader = prepare_dataloader(device)
 
     loss_fn = torch.nn.CrossEntropyLoss()
-    metric = MulticlassAccuracy().to(device)
-    throughtput = Throughput().to(device)
+    metric = MulticlassAccuracy(device=device)
+    throughtput = Throughput(device=device)
 
     num_epochs_completed = 0
     while num_epochs_completed < NUM_EPOCHS:

--- a/torcheval/metrics/aggregation/cat.py
+++ b/torcheval/metrics/aggregation/cat.py
@@ -7,7 +7,7 @@
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
 
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -46,14 +46,18 @@ class Cat(Metric[torch.Tensor]):
         tensor([0])
     """
 
-    def __init__(self: "Cat", dim: int = 0) -> None:
+    def __init__(
+        self: "Cat",
+        dim: int = 0,
+        device: Optional[torch.device] = None,
+    ) -> None:
         """
         Initialize a Cat metric object.
 
         Args:
             dim: The dimension along which to concatenate, as in ``torch.cat()``.
         """
-        super().__init__()
+        super().__init__(device=device)
         self.dim = dim
         self._add_state("inputs", [])
 

--- a/torcheval/metrics/aggregation/max.py
+++ b/torcheval/metrics/aggregation/max.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -37,9 +37,12 @@ class Max(Metric[torch.Tensor]):
         tensor(-1.)
     """
 
-    def __init__(self: TMax) -> None:
-        super().__init__()
-        self._add_state("max", torch.tensor(float("-inf")))
+    def __init__(
+        self: TMax,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("max", torch.tensor(float("-inf"), device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/aggregation/mean.py
+++ b/torcheval/metrics/aggregation/mean.py
@@ -7,7 +7,7 @@
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
 import logging
-from typing import Iterable, TypeVar, Union
+from typing import Iterable, Optional, TypeVar, Union
 
 import torch
 
@@ -48,10 +48,13 @@ class Mean(Metric[torch.Tensor]):
         tensor(4.825)
     """
 
-    def __init__(self: TMean) -> None:
-        super().__init__()
-        self._add_state("weighted_sum", torch.tensor(0.0))
-        self._add_state("weights", torch.tensor(0.0))
+    def __init__(
+        self: TMean,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("weighted_sum", torch.tensor(0.0, device=self.device))
+        self._add_state("weights", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/aggregation/min.py
+++ b/torcheval/metrics/aggregation/min.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -37,9 +37,12 @@ class Min(Metric[torch.Tensor]):
         tensor(5.)
     """
 
-    def __init__(self: TMin) -> None:
-        super().__init__()
-        self._add_state("min", torch.tensor(float("inf")))
+    def __init__(
+        self: TMin,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("min", torch.tensor(float("inf"), device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/aggregation/sum.py
+++ b/torcheval/metrics/aggregation/sum.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, TypeVar, Union
+from typing import Iterable, Optional, TypeVar, Union
 
 import torch
 
@@ -45,9 +45,12 @@ class Sum(Metric[torch.Tensor]):
         tensor(14.5)
     """
 
-    def __init__(self: TSum) -> None:
-        super().__init__()
-        self._add_state("weighted_sum", torch.tensor(0.0))
+    def __init__(
+        self: TSum,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("weighted_sum", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/aggregation/throughput.py
+++ b/torcheval/metrics/aggregation/throughput.py
@@ -7,7 +7,7 @@
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
 import logging
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -41,10 +41,16 @@ class Throughput(Metric[torch.Tensor]):
         tensor(32.)
     """
 
-    def __init__(self: TThroughput) -> None:
-        super().__init__()
-        self._add_state("num_total", torch.tensor(0.0))
-        self._add_state("elapsed_time_sec", torch.tensor(0.0))
+    def __init__(
+        self: TThroughput,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("num_total", torch.tensor(0.0, device=self.device))
+        self._add_state(
+            "elapsed_time_sec",
+            torch.tensor(0.0, device=self.device),
+        )
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/classification/accuracy.py
+++ b/torcheval/metrics/classification/accuracy.py
@@ -84,19 +84,26 @@ class MulticlassAccuracy(Metric[torch.Tensor]):
         average: Optional[str] = "micro",
         num_classes: Optional[int] = None,
         k: int = 1,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _accuracy_param_check(average, num_classes, k)
         self.average = average
         self.num_classes = num_classes
         self.k = k
         if average == "micro":
-            self._add_state("num_correct", torch.tensor(0.0))
-            self._add_state("num_total", torch.tensor(0.0))
+            self._add_state("num_correct", torch.tensor(0.0, device=self.device))
+            self._add_state("num_total", torch.tensor(0.0, device=self.device))
         else:
             # num_classes is verified to be not None when average != "micro"
-            self._add_state("num_correct", torch.zeros(num_classes or 0))
-            self._add_state("num_total", torch.zeros(num_classes or 0))
+            self._add_state(
+                "num_correct",
+                torch.zeros(num_classes or 0, device=self.device),
+            )
+            self._add_state(
+                "num_total",
+                torch.zeros(num_classes or 0, device=self.device),
+            )
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
@@ -164,8 +171,9 @@ class BinaryAccuracy(MulticlassAccuracy):
     def __init__(
         self: TBinaryAccuracy,
         threshold: float = 0.5,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         self.threshold = threshold
 
     @torch.inference_mode()
@@ -225,8 +233,9 @@ class MultilabelAccuracy(MulticlassAccuracy):
         self: TMultilabelAccuracy,
         threshold: float = 0.5,
         criteria: str = "exact_match",
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _multilabel_accuracy_param_check(criteria)
         self.threshold = threshold
         self.criteria = criteria

--- a/torcheval/metrics/classification/auroc.py
+++ b/torcheval/metrics/classification/auroc.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -43,8 +43,9 @@ class BinaryAUROC(Metric[torch.Tensor]):
 
     def __init__(
         self: TAUROC,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         self._add_state("inputs", [])
         self._add_state("targets", [])
 

--- a/torcheval/metrics/classification/binary_normalized_entropy.py
+++ b/torcheval/metrics/classification/binary_normalized_entropy.py
@@ -48,12 +48,22 @@ class BinaryNormalizedEntropy(Metric[torch.Tensor]):
         tensor(1.4183)
     """
 
-    def __init__(self: TNormalizedEntropy, from_logits: bool = False) -> None:
-        super().__init__()
+    def __init__(
+        self: TNormalizedEntropy,
+        from_logits: bool = False,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
         self.from_logits = from_logits
-        self._add_state("total_entropy", torch.tensor(0.0, dtype=torch.float64))
-        self._add_state("num_examples", torch.tensor(0.0, dtype=torch.float64))
-        self._add_state("num_positive", torch.tensor(0.0, dtype=torch.float64))
+        self._add_state(
+            "total_entropy", torch.tensor(0.0, dtype=torch.float64, device=self.device)
+        )
+        self._add_state(
+            "num_examples", torch.tensor(0.0, dtype=torch.float64, device=self.device)
+        )
+        self._add_state(
+            "num_positive", torch.tensor(0.0, dtype=torch.float64, device=self.device)
+        )
 
     @torch.inference_mode()
     # pyre-ignore[14]: `update` overrides method defined in `Metric` inconsistently.

--- a/torcheval/metrics/classification/binned_precision_recall_curve.py
+++ b/torcheval/metrics/classification/binned_precision_recall_curve.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, List, Tuple, TypeVar, Union
+from typing import Iterable, List, Optional, Tuple, TypeVar, Union
 
 import torch
 
@@ -58,18 +58,19 @@ class BinaryBinnedPrecisionRecallCurve(Metric[torch.Tensor]):
     def __init__(
         self: TBinaryBinnedPrecisionRecallCurve,
         threshold: Union[int, List[float], torch.Tensor] = 100,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         threshold = (
-            torch.linspace(0, 1.0, threshold)
+            torch.linspace(0, 1.0, threshold, device=self.device)
             if isinstance(threshold, int)
-            else torch.tensor(threshold)
+            else torch.tensor(threshold, device=self.device)
         )
         _binary_binned_precision_recall_curve_param_check(threshold)
         self._add_state("threshold", threshold)
-        self._add_state("num_tp", torch.zeros(len(threshold)))
-        self._add_state("num_fp", torch.zeros(len(threshold)))
-        self._add_state("num_fn", torch.zeros(len(threshold)))
+        self._add_state("num_tp", torch.zeros(len(threshold), device=self.device))
+        self._add_state("num_fp", torch.zeros(len(threshold), device=self.device))
+        self._add_state("num_fn", torch.zeros(len(threshold), device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/classification/f1_score.py
+++ b/torcheval/metrics/classification/f1_score.py
@@ -81,24 +81,37 @@ class MulticlassF1Score(Metric[torch.Tensor]):
         self: TF1Score,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _f1_score_param_check(num_classes, average)
         self.num_classes = num_classes
         self.average = average
         if average == "micro":
-            self._add_state("num_tp", torch.tensor(0.0))
-            self._add_state("num_label", torch.tensor(0.0))
-            self._add_state("num_prediction", torch.tensor(0.0))
+            self._add_state("num_tp", torch.tensor(0.0, device=self.device))
+            self._add_state("num_label", torch.tensor(0.0, device=self.device))
+            self._add_state(
+                "num_prediction",
+                torch.tensor(0.0, device=self.device),
+            )
         else:
             # num_classes has been verified as a positive integer. Add this line to bypass pyre.
             assert isinstance(
                 num_classes, int
             ), f"num_classes must be a integer, but got {num_classes}"
 
-            self._add_state("num_tp", torch.zeros(num_classes))
-            self._add_state("num_label", torch.zeros(num_classes))
-            self._add_state("num_prediction", torch.zeros(num_classes))
+            self._add_state(
+                "num_tp",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_label",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_prediction",
+                torch.zeros(num_classes, device=self.device),
+            )
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/classification/precision.py
+++ b/torcheval/metrics/classification/precision.py
@@ -82,24 +82,34 @@ class MulticlassPrecision(Metric[torch.Tensor]):
         self: TPrecision,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _precision_param_check(num_classes, average)
         self.num_classes = num_classes
         self.average = average
         if average == "micro":
-            self._add_state("num_tp", torch.tensor(0.0))
-            self._add_state("num_fp", torch.tensor(0.0))
-            self._add_state("num_label", torch.tensor(0.0))
+            self._add_state("num_tp", torch.tensor(0.0, device=self.device))
+            self._add_state("num_fp", torch.tensor(0.0, device=self.device))
+            self._add_state("num_label", torch.tensor(0.0, device=self.device))
         else:
             # num_classes has been verified as a positive integer. Add this line to bypass pyre.
             assert isinstance(
                 num_classes, int
             ), f"num_classes must be a integer, but got {num_classes}"
 
-            self._add_state("num_tp", torch.zeros(num_classes))
-            self._add_state("num_fp", torch.zeros(num_classes))
-            self._add_state("num_label", torch.zeros(num_classes))
+            self._add_state(
+                "num_tp",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_fp",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_label",
+                torch.zeros(num_classes, device=self.device),
+            )
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
@@ -177,8 +187,9 @@ class BinaryPrecision(MulticlassPrecision):
     def __init__(
         self: TBinaryPrecision,
         threshold: float = 0.5,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__(num_classes=2)
+        super().__init__(num_classes=2, device=device)
         self.threshold = threshold
 
     @torch.inference_mode()

--- a/torcheval/metrics/classification/precision_recall_curve.py
+++ b/torcheval/metrics/classification/precision_recall_curve.py
@@ -47,8 +47,9 @@ class BinaryPrecisionRecallCurve(Metric[torch.Tensor]):
 
     def __init__(
         self: TBinaryPrecisionRecallCurve,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         self._add_state("inputs", [])
         self._add_state("targets", [])
 
@@ -146,8 +147,9 @@ class MulticlassPrecisionRecallCurve(Metric[torch.Tensor]):
     def __init__(
         self: TMulticlassPrecisionRecallCurve,
         num_classes: Optional[int] = None,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         self.num_classes = num_classes
         self._add_state("inputs", [])
         self._add_state("targets", [])

--- a/torcheval/metrics/classification/recall.py
+++ b/torcheval/metrics/classification/recall.py
@@ -63,12 +63,13 @@ class BinaryRecall(Metric[torch.Tensor]):
     def __init__(
         self: TBinaryRecall,
         threshold: float = 0.5,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         self.threshold = threshold
 
-        self._add_state("num_tp", torch.tensor(0.0))
-        self._add_state("num_true_labels", torch.tensor(0.0))
+        self._add_state("num_tp", torch.tensor(0.0, device=self.device))
+        self._add_state("num_true_labels", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
@@ -168,23 +169,36 @@ class MulticlassRecall(Metric[torch.Tensor]):
         self: TRecall,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _recall_param_check(num_classes, average)
         self.num_classes = num_classes
         self.average = average
 
         if average == "micro":
-            self._add_state("num_tp", torch.tensor(0.0))
-            self._add_state("num_labels", torch.tensor(0.0))
-            self._add_state("num_predictions", torch.tensor(0.0))
+            self._add_state("num_tp", torch.tensor(0.0, device=self.device))
+            self._add_state("num_labels", torch.tensor(0.0, device=self.device))
+            self._add_state(
+                "num_predictions",
+                torch.tensor(0.0, device=self.device),
+            )
         else:
             assert isinstance(
                 num_classes, int
             ), f"`num_classes` must be an integer, but got {num_classes}."
-            self._add_state("num_tp", torch.zeros(num_classes))
-            self._add_state("num_labels", torch.zeros(num_classes))
-            self._add_state("num_predictions", torch.zeros(num_classes))
+            self._add_state(
+                "num_tp",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_labels",
+                torch.zeros(num_classes, device=self.device),
+            )
+            self._add_state(
+                "num_predictions",
+                torch.zeros(num_classes, device=self.device),
+            )
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/metric.py
+++ b/torcheval/metrics/metric.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from copy import deepcopy
-from typing import Any, Deque, Dict, Generic, Iterable, List, TypeVar, Union
+from typing import Any, Deque, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
 import torch
 
@@ -28,7 +28,10 @@ class Metric(Generic[TComputeReturn], ABC):
     to implement your own metric.
     """
 
-    def __init__(self: TSelf) -> None:
+    def __init__(
+        self: TSelf,
+        device: Optional[torch.device] = None,
+    ) -> None:
         """
         Initialize a metric object and its internal states.
 
@@ -43,7 +46,7 @@ class Metric(Generic[TComputeReturn], ABC):
         # data structures when move/detach/clone tensors. Can open more types up
         # upon user requests in the future.
         self._state_name_to_default: Dict[str, TState] = {}
-        self._device: torch.device = torch.device("cpu")
+        self._device: torch.device = torch.device("cpu") if device is None else device
 
     def _add_state(self: TSelf, name: str, default: TState) -> None:
         """

--- a/torcheval/metrics/ranking/hit_rate.py
+++ b/torcheval/metrics/ranking/hit_rate.py
@@ -42,8 +42,12 @@ class HitRate(Metric[torch.Tensor]):
         tensor([1., 0., 0., 1.])
     """
 
-    def __init__(self: THitRate, k: Optional[int] = None) -> None:
-        super().__init__()
+    def __init__(
+        self: THitRate,
+        k: Optional[int] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
         self.k = k
         self._add_state("scores", [])
 

--- a/torcheval/metrics/ranking/reciprocal_rank.py
+++ b/torcheval/metrics/ranking/reciprocal_rank.py
@@ -42,8 +42,12 @@ class ReciprocalRank(Metric[torch.Tensor]):
         tensor([1.0000, 0.0000, 0.0000, 0.5000])
     """
 
-    def __init__(self: TReciprocalRank, k: Optional[int] = None) -> None:
-        super().__init__()
+    def __init__(
+        self: TReciprocalRank,
+        k: Optional[int] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(device=device)
         self.k = k
         self._add_state("scores", [])
 

--- a/torcheval/metrics/regression/mean_squared_error.py
+++ b/torcheval/metrics/regression/mean_squared_error.py
@@ -72,12 +72,16 @@ class MeanSquaredError(Metric[torch.Tensor]):
     def __init__(
         self: TMeanSquaredError,
         multioutput: str = "uniform_average",
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _mean_squared_error_param_check(multioutput)
         self.multioutput = multioutput
-        self._add_state("sum_squared_error", torch.tensor(0.0))
-        self._add_state("sum_weight", torch.tensor(0.0))
+        self._add_state(
+            "sum_squared_error",
+            torch.tensor(0.0, device=self.device),
+        )
+        self._add_state("sum_weight", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any

--- a/torcheval/metrics/regression/r2_score.py
+++ b/torcheval/metrics/regression/r2_score.py
@@ -6,7 +6,7 @@
 
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -83,15 +83,19 @@ class R2Score(Metric[torch.Tensor]):
         self: TR2Score,
         multioutput: str = "uniform_average",
         num_regressors: int = 0,
+        device: Optional[torch.device] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(device=device)
         _r2_score_param_check(multioutput, num_regressors)
         self.multioutput = multioutput
         self.num_regressors = num_regressors
-        self._add_state("sum_squared_obs", torch.tensor(0.0))
-        self._add_state("sum_obs", torch.tensor(0.0))
-        self._add_state("sum_squared_residual", torch.tensor(0.0))
-        self._add_state("num_obs", torch.tensor(0.0))
+        self._add_state("sum_squared_obs", torch.tensor(0.0, device=self.device))
+        self._add_state("sum_obs", torch.tensor(0.0, device=self.device))
+        self._add_state(
+            "sum_squared_residual",
+            torch.tensor(0.0, device=self.device),
+        )
+        self._add_state("num_obs", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any


### PR DESCRIPTION
Summary: Add `device` optional parameters to the constructor of several metric classes. Pass  `device` to tensors within the metric classes.

Differential Revision: D38596493

