### PR TITLE
Enforce convention of passing arguments by name

### DIFF
--- a/tests/metrics/aggregation/test_mean.py
+++ b/tests/metrics/aggregation/test_mean.py
@@ -106,4 +106,4 @@ class TestMean(MetricClassTester):
             ValueError,
             r"Weight must be either a float value or a tensor that matches the input tensor size.",
         ):
-            metric.update(torch.tensor([2.0, 3.0]), torch.tensor([0.5]))
+            metric.update(torch.tensor([2.0, 3.0]), weight=torch.tensor([0.5]))

--- a/tests/metrics/aggregation/test_sum.py
+++ b/tests/metrics/aggregation/test_sum.py
@@ -94,7 +94,7 @@ class TestSum(MetricClassTester):
             ValueError,
             r"Weight must be either a float value or an int value or a tensor that matches the input tensor size.",
         ):
-            metric.update(torch.tensor([2.0, 3.0]), torch.tensor([0.5]))
+            metric.update(torch.tensor([2.0, 3.0]), weight=torch.tensor([0.5]))
 
     def test_sum_class_compute_without_update(self) -> None:
         metric = Sum()

--- a/tests/metrics/classification/test_binned_precision_recall_curve.py
+++ b/tests/metrics/classification/test_binned_precision_recall_curve.py
@@ -26,7 +26,7 @@ class TestBinaryBinnedPrecisionRecallCurve(MetricClassTester):
     ) -> None:
 
         compute_result = binary_binned_precision_recall_curve(
-            input.reshape(-1), target.reshape(-1), threshold
+            input.reshape(-1), target.reshape(-1), threshold=threshold
         )
 
         self.run_class_implementation_tests(
@@ -99,7 +99,9 @@ class TestBinaryBinnedPrecisionRecallCurve(MetricClassTester):
         )
 
     def test_binary_binned_precision_recall_curve_class_invalid_input(self) -> None:
-        metric = BinaryBinnedPrecisionRecallCurve(torch.tensor([0.1, 0.5, 0.9]))
+        metric = BinaryBinnedPrecisionRecallCurve(
+            threshold=torch.tensor([0.1, 0.5, 0.9])
+        )
         with self.assertRaisesRegex(
             ValueError,
             "input should be a one-dimensional tensor, "
@@ -124,16 +126,18 @@ class TestBinaryBinnedPrecisionRecallCurve(MetricClassTester):
         with self.assertRaisesRegex(
             ValueError, "The `threshold` should be a sorted array."
         ):
-            BinaryBinnedPrecisionRecallCurve(torch.tensor([0.1, 0.9, 0.5]))
+            BinaryBinnedPrecisionRecallCurve(threshold=torch.tensor([0.1, 0.9, 0.5]))
 
         with self.assertRaisesRegex(
             ValueError,
             r"The values in `threshold` should be in the range of \[0, 1\].",
         ):
-            BinaryBinnedPrecisionRecallCurve(torch.tensor([-0.1, 0.5, 0.9]))
+            BinaryBinnedPrecisionRecallCurve(threshold=torch.tensor([-0.1, 0.5, 0.9]))
 
         with self.assertRaisesRegex(
             ValueError,
             r"The values in `threshold` should be in the range of \[0, 1\].",
         ):
-            BinaryBinnedPrecisionRecallCurve(torch.tensor([0.1, 0.2, 0.5, 1.7]))
+            BinaryBinnedPrecisionRecallCurve(
+                threshold=torch.tensor([0.1, 0.2, 0.5, 1.7])
+            )

--- a/tests/metrics/classification/test_normalized_entropy.py
+++ b/tests/metrics/classification/test_normalized_entropy.py
@@ -63,7 +63,9 @@ class TestBinaryNormalizedEntropy(MetricClassTester):
 
         with self.assertRaisesRegex(ValueError, "is different from `input` shape"):
             metric.update(
-                torch.rand((5,)), torch.randint(0, 2, (5,)), torch.randint(0, 20, (3,))
+                torch.rand((5,)),
+                torch.randint(0, 2, (5,)),
+                weight=torch.randint(0, 20, (3,)),
             )
         with self.assertRaisesRegex(
             ValueError,

--- a/tests/metrics/functional/classification/test_binned_precision_recall_curve.py
+++ b/tests/metrics/functional/classification/test_binned_precision_recall_curve.py
@@ -22,7 +22,7 @@ class TestBinaryBinnedPrecisionRecallCurve(unittest.TestCase):
         my_compute_result = binary_binned_precision_recall_curve(
             input,
             target,
-            threshold,
+            threshold=threshold,
         )
         _test_helper(input, target, my_compute_result, compute_result)
 
@@ -102,21 +102,27 @@ class TestBinaryBinnedPrecisionRecallCurve(unittest.TestCase):
             ValueError, "The `threshold` should be a sorted array."
         ):
             binary_binned_precision_recall_curve(
-                torch.rand(4), torch.rand(4), torch.tensor([0.1, 0.2, 0.5, 0.7, 0.6])
+                torch.rand(4),
+                torch.rand(4),
+                threshold=torch.tensor([0.1, 0.2, 0.5, 0.7, 0.6]),
             )
         with self.assertRaisesRegex(
             ValueError,
             r"The values in `threshold` should be in the range of \[0, 1\].",
         ):
             binary_binned_precision_recall_curve(
-                torch.rand(4), torch.rand(4), torch.tensor([-0.1, 0.2, 0.5, 0.7])
+                torch.rand(4),
+                torch.rand(4),
+                threshold=torch.tensor([-0.1, 0.2, 0.5, 0.7]),
             )
         with self.assertRaisesRegex(
             ValueError,
             r"The values in `threshold` should be in the range of \[0, 1\].",
         ):
             binary_binned_precision_recall_curve(
-                torch.rand(4), torch.rand(4), torch.tensor([0.1, 0.2, 0.5, 1.7])
+                torch.rand(4),
+                torch.rand(4),
+                threshold=torch.tensor([0.1, 0.2, 0.5, 1.7]),
             )
 
 

--- a/tests/metrics/functional/classification/test_normalized_entropy.py
+++ b/tests/metrics/functional/classification/test_normalized_entropy.py
@@ -25,7 +25,7 @@ class TestBinaryNormalizedEntropy(unittest.TestCase):
 
         # with weight and input are probability value
         torch.testing.assert_close(
-            binary_normalized_entropy(input, target, weight, from_logits=False),
+            binary_normalized_entropy(input, target, weight=weight, from_logits=False),
             torch.tensor(1.0060274419349144, dtype=torch.float64),
         )
 
@@ -39,7 +39,9 @@ class TestBinaryNormalizedEntropy(unittest.TestCase):
 
         # with weight and input are logit value
         torch.testing.assert_close(
-            binary_normalized_entropy(input_logit, target, weight, from_logits=True),
+            binary_normalized_entropy(
+                input_logit, target, weight=weight, from_logits=True
+            ),
             torch.tensor(1.0060274419349144, dtype=torch.float64),
         )
 
@@ -49,7 +51,9 @@ class TestBinaryNormalizedEntropy(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "is different from `input` shape"):
             binary_normalized_entropy(
-                torch.rand((5,)), torch.randint(0, 2, (5,)), torch.randint(0, 20, (3,))
+                torch.rand((5,)),
+                torch.randint(0, 2, (5,)),
+                weight=torch.randint(0, 20, (3,)),
             )
         with self.assertRaisesRegex(
             ValueError,

--- a/tests/metrics/functional/classification/test_precision.py
+++ b/tests/metrics/functional/classification/test_precision.py
@@ -33,7 +33,7 @@ class TestBinaryPrecision(unittest.TestCase):
         )
 
         torch.testing.assert_close(
-            binary_precision(input, target, threshold),
+            binary_precision(input, target, threshold=threshold),
             sklearn_result,
             equal_nan=True,
             atol=1e-8,

--- a/tests/metrics/functional/regression/test_r2_score.py
+++ b/tests/metrics/functional/regression/test_r2_score.py
@@ -30,7 +30,9 @@ class TestR2Score(unittest.TestCase):
             compute_result = 1 - (1 - compute_result) * (num_obs - 1) / (
                 num_obs - num_regressors - 1
             )
-        my_compute_result = my_r2_score(input, target, multioutput, num_regressors)
+        my_compute_result = my_r2_score(
+            input, target, multioutput=multioutput, num_regressors=num_regressors
+        )
         torch.testing.assert_close(
             my_compute_result,
             compute_result,

--- a/torcheval/metrics/aggregation/cat.py
+++ b/torcheval/metrics/aggregation/cat.py
@@ -48,6 +48,7 @@ class Cat(Metric[torch.Tensor]):
 
     def __init__(
         self: "Cat",
+        *,
         dim: int = 0,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/aggregation/max.py
+++ b/torcheval/metrics/aggregation/max.py
@@ -39,6 +39,7 @@ class Max(Metric[torch.Tensor]):
 
     def __init__(
         self: TMax,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)

--- a/torcheval/metrics/aggregation/mean.py
+++ b/torcheval/metrics/aggregation/mean.py
@@ -50,6 +50,7 @@ class Mean(Metric[torch.Tensor]):
 
     def __init__(
         self: TMean,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)
@@ -59,7 +60,10 @@ class Mean(Metric[torch.Tensor]):
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
     def update(
-        self: TMean, input: torch.Tensor, weight: Union[float, int, torch.Tensor] = 1.0
+        self: TMean,
+        input: torch.Tensor,
+        *,
+        weight: Union[float, int, torch.Tensor] = 1.0,
     ) -> TMean:
         """
         Compute weighted mean. When weight is not provided, it calculates the unweighted mean.

--- a/torcheval/metrics/aggregation/min.py
+++ b/torcheval/metrics/aggregation/min.py
@@ -39,6 +39,7 @@ class Min(Metric[torch.Tensor]):
 
     def __init__(
         self: TMin,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)

--- a/torcheval/metrics/aggregation/sum.py
+++ b/torcheval/metrics/aggregation/sum.py
@@ -47,6 +47,7 @@ class Sum(Metric[torch.Tensor]):
 
     def __init__(
         self: TSum,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)
@@ -55,7 +56,10 @@ class Sum(Metric[torch.Tensor]):
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
     def update(
-        self: TSum, input: torch.Tensor, weight: Union[float, int, torch.Tensor] = 1.0
+        self: TSum,
+        input: torch.Tensor,
+        *,
+        weight: Union[float, int, torch.Tensor] = 1.0,
     ) -> TSum:
         """
         Update states with the values and weights.

--- a/torcheval/metrics/aggregation/throughput.py
+++ b/torcheval/metrics/aggregation/throughput.py
@@ -43,6 +43,7 @@ class Throughput(Metric[torch.Tensor]):
 
     def __init__(
         self: TThroughput,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)

--- a/torcheval/metrics/classification/accuracy.py
+++ b/torcheval/metrics/classification/accuracy.py
@@ -81,6 +81,7 @@ class MulticlassAccuracy(Metric[torch.Tensor]):
 
     def __init__(
         self: TAccuracy,
+        *,
         average: Optional[str] = "micro",
         num_classes: Optional[int] = None,
         k: int = 1,
@@ -170,6 +171,7 @@ class BinaryAccuracy(MulticlassAccuracy):
 
     def __init__(
         self: TBinaryAccuracy,
+        *,
         threshold: float = 0.5,
         device: Optional[torch.device] = None,
     ) -> None:
@@ -231,6 +233,7 @@ class MultilabelAccuracy(MulticlassAccuracy):
 
     def __init__(
         self: TMultilabelAccuracy,
+        *,
         threshold: float = 0.5,
         criteria: str = "exact_match",
         device: Optional[torch.device] = None,

--- a/torcheval/metrics/classification/auroc.py
+++ b/torcheval/metrics/classification/auroc.py
@@ -43,6 +43,7 @@ class BinaryAUROC(Metric[torch.Tensor]):
 
     def __init__(
         self: TAUROC,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)

--- a/torcheval/metrics/classification/binary_normalized_entropy.py
+++ b/torcheval/metrics/classification/binary_normalized_entropy.py
@@ -50,6 +50,7 @@ class BinaryNormalizedEntropy(Metric[torch.Tensor]):
 
     def __init__(
         self: TNormalizedEntropy,
+        *,
         from_logits: bool = False,
         device: Optional[torch.device] = None,
     ) -> None:
@@ -71,6 +72,7 @@ class BinaryNormalizedEntropy(Metric[torch.Tensor]):
         self: TNormalizedEntropy,
         input: torch.Tensor,
         target: torch.Tensor,
+        *,
         weight: Optional[torch.Tensor] = None,
     ) -> TNormalizedEntropy:
         """

--- a/torcheval/metrics/classification/binned_precision_recall_curve.py
+++ b/torcheval/metrics/classification/binned_precision_recall_curve.py
@@ -57,6 +57,7 @@ class BinaryBinnedPrecisionRecallCurve(Metric[torch.Tensor]):
 
     def __init__(
         self: TBinaryBinnedPrecisionRecallCurve,
+        *,
         threshold: Union[int, List[float], torch.Tensor] = 100,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/classification/f1_score.py
+++ b/torcheval/metrics/classification/f1_score.py
@@ -79,6 +79,7 @@ class MulticlassF1Score(Metric[torch.Tensor]):
 
     def __init__(
         self: TF1Score,
+        *,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
         device: Optional[torch.device] = None,

--- a/torcheval/metrics/classification/precision.py
+++ b/torcheval/metrics/classification/precision.py
@@ -80,6 +80,7 @@ class MulticlassPrecision(Metric[torch.Tensor]):
 
     def __init__(
         self: TPrecision,
+        *,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
         device: Optional[torch.device] = None,
@@ -186,6 +187,7 @@ class BinaryPrecision(MulticlassPrecision):
 
     def __init__(
         self: TBinaryPrecision,
+        *,
         threshold: float = 0.5,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/classification/precision_recall_curve.py
+++ b/torcheval/metrics/classification/precision_recall_curve.py
@@ -47,6 +47,7 @@ class BinaryPrecisionRecallCurve(Metric[torch.Tensor]):
 
     def __init__(
         self: TBinaryPrecisionRecallCurve,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(device=device)
@@ -146,6 +147,7 @@ class MulticlassPrecisionRecallCurve(Metric[torch.Tensor]):
 
     def __init__(
         self: TMulticlassPrecisionRecallCurve,
+        *,
         num_classes: Optional[int] = None,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/classification/recall.py
+++ b/torcheval/metrics/classification/recall.py
@@ -62,6 +62,7 @@ class BinaryRecall(Metric[torch.Tensor]):
 
     def __init__(
         self: TBinaryRecall,
+        *,
         threshold: float = 0.5,
         device: Optional[torch.device] = None,
     ) -> None:
@@ -167,6 +168,7 @@ class MulticlassRecall(Metric[torch.Tensor]):
 
     def __init__(
         self: TRecall,
+        *,
         num_classes: Optional[int] = None,
         average: Optional[str] = "micro",
         device: Optional[torch.device] = None,

--- a/torcheval/metrics/functional/classification/accuracy.py
+++ b/torcheval/metrics/functional/classification/accuracy.py
@@ -13,11 +13,12 @@ import torch
 def binary_accuracy(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     threshold: float = 0.5,
 ) -> torch.Tensor:
     """
     Compute binary accuracy score, which is the frequency of input matching target.
-    Its functional version is ``torcheval.metrics.functional.binary_accuracy``.
+    Its class version is ``torcheval.metrics.BinaryAccuracy``.
 
     Args:
         input: Tensor of label predictions with shape of (n_sample,).
@@ -27,19 +28,15 @@ def binary_accuracy(
             ``torch.where(input < threshold, 0, 1)`` will be applied to the ``input``.
     Example:
         >>> import torch
-        >>> from torcheval.metrics import BinaryAccuracy
-        >>> metric = BinaryAccuracy()
+        >>> from torcheval.metrics.functional import binary_accuracy
         >>> input = torch.tensor([0, 0, 1, 1])
         >>> target = torch.tensor([1, 0, 1, 1])
-        >>> metric.update(input, target)
-        >>> metric.compute()
+        >>> binary_accuracy(input, target)
         tensor(0.75)  # 3 / 4
 
-        >>> metric = BinaryAccuracy(threshold=0.7)
         >>> input = torch.tensor([0, 0.2, 0.6, 0.7])
         >>> target = torch.tensor([1, 0, 1, 1])
-        >>> metric.update(input, target)
-        >>> metric.compute()
+        >>> binary_accuracy(input, target, threshold=0.7)
         tensor(0.5)  # 2 / 4
     """
 
@@ -51,6 +48,7 @@ def binary_accuracy(
 def multiclass_accuracy(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     average: Optional[str] = "micro",
     num_classes: Optional[int] = None,
     k: int = 1,
@@ -107,6 +105,7 @@ def multiclass_accuracy(
 def multilabel_accuracy(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     threshold: float = 0.5,
     criteria: str = "exact_match",
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/classification/binary_normalized_entropy.py
+++ b/torcheval/metrics/functional/classification/binary_normalized_entropy.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 def binary_normalized_entropy(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     weight: Optional[torch.Tensor] = None,
     from_logits: bool = False,
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/classification/binned_precision_recall_curve.py
+++ b/torcheval/metrics/functional/classification/binned_precision_recall_curve.py
@@ -13,6 +13,7 @@ import torch
 def binary_binned_precision_recall_curve(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     threshold: Union[int, List[float], torch.Tensor] = 100,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """

--- a/torcheval/metrics/functional/classification/f1_score.py
+++ b/torcheval/metrics/functional/classification/f1_score.py
@@ -16,6 +16,7 @@ import torch
 def multiclass_f1_score(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     num_classes: Optional[int] = None,
     average: Optional[str] = "micro",
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/classification/precision.py
+++ b/torcheval/metrics/functional/classification/precision.py
@@ -17,6 +17,7 @@ import torch
 def binary_precision(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     threshold: float = 0.5,
 ) -> torch.Tensor:
     """
@@ -53,6 +54,7 @@ def binary_precision(
 def multiclass_precision(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     num_classes: Optional[int] = None,
     average: Optional[str] = "micro",
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/classification/precision_recall_curve.py
+++ b/torcheval/metrics/functional/classification/precision_recall_curve.py
@@ -92,6 +92,7 @@ def _binary_precision_recall_curve_update_input_check(
 def multiclass_precision_recall_curve(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     num_classes: Optional[int] = None,
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor], List[torch.Tensor]]:
     """

--- a/torcheval/metrics/functional/classification/recall.py
+++ b/torcheval/metrics/functional/classification/recall.py
@@ -14,6 +14,7 @@ import torch
 def binary_recall(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     threshold: float = 0.5,
 ) -> torch.Tensor:
     """
@@ -94,6 +95,7 @@ def _binary_recall_update_input_check(
 def multiclass_recall(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     num_classes: Optional[int] = None,
     average: Optional[str] = "micro",
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/ranking/hit_rate.py
+++ b/torcheval/metrics/functional/ranking/hit_rate.py
@@ -13,6 +13,7 @@ import torch
 def hit_rate(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     k: Optional[int] = None,
 ) -> torch.Tensor:
     """

--- a/torcheval/metrics/functional/ranking/reciprocal_rank.py
+++ b/torcheval/metrics/functional/ranking/reciprocal_rank.py
@@ -13,6 +13,7 @@ import torch
 def reciprocal_rank(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     k: Optional[int] = None,
 ) -> torch.Tensor:
     """

--- a/torcheval/metrics/functional/regression/mean_squared_error.py
+++ b/torcheval/metrics/functional/regression/mean_squared_error.py
@@ -13,6 +13,7 @@ import torch
 def mean_squared_error(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     sample_weight: Optional[torch.Tensor] = None,
     multioutput: str = "uniform_average",
 ) -> torch.Tensor:

--- a/torcheval/metrics/functional/regression/r2_score.py
+++ b/torcheval/metrics/functional/regression/r2_score.py
@@ -15,6 +15,7 @@ import torch
 def r2_score(
     input: torch.Tensor,
     target: torch.Tensor,
+    *,
     multioutput: str = "uniform_average",
     num_regressors: int = 0,
 ) -> torch.Tensor:

--- a/torcheval/metrics/metric.py
+++ b/torcheval/metrics/metric.py
@@ -30,6 +30,7 @@ class Metric(Generic[TComputeReturn], ABC):
 
     def __init__(
         self: TSelf,
+        *,
         device: Optional[torch.device] = None,
     ) -> None:
         """

--- a/torcheval/metrics/ranking/hit_rate.py
+++ b/torcheval/metrics/ranking/hit_rate.py
@@ -44,6 +44,7 @@ class HitRate(Metric[torch.Tensor]):
 
     def __init__(
         self: THitRate,
+        *,
         k: Optional[int] = None,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/ranking/reciprocal_rank.py
+++ b/torcheval/metrics/ranking/reciprocal_rank.py
@@ -44,6 +44,7 @@ class ReciprocalRank(Metric[torch.Tensor]):
 
     def __init__(
         self: TReciprocalRank,
+        *,
         k: Optional[int] = None,
         device: Optional[torch.device] = None,
     ) -> None:

--- a/torcheval/metrics/regression/mean_squared_error.py
+++ b/torcheval/metrics/regression/mean_squared_error.py
@@ -71,6 +71,7 @@ class MeanSquaredError(Metric[torch.Tensor]):
 
     def __init__(
         self: TMeanSquaredError,
+        *,
         multioutput: str = "uniform_average",
         device: Optional[torch.device] = None,
     ) -> None:
@@ -89,6 +90,7 @@ class MeanSquaredError(Metric[torch.Tensor]):
         self: TMeanSquaredError,
         input: torch.Tensor,
         target: torch.Tensor,
+        *,
         sample_weight: Optional[torch.Tensor] = None,
     ) -> TMeanSquaredError:
         """

--- a/torcheval/metrics/regression/r2_score.py
+++ b/torcheval/metrics/regression/r2_score.py
@@ -81,6 +81,7 @@ class R2Score(Metric[torch.Tensor]):
 
     def __init__(
         self: TR2Score,
+        *,
         multioutput: str = "uniform_average",
         num_regressors: int = 0,
         device: Optional[torch.device] = None,

--- a/torcheval/utils/test_utils/dummy_metric.py
+++ b/torcheval/utils/test_utils/dummy_metric.py
@@ -7,7 +7,7 @@
 # pyre-ignore-all-errors[16]: Undefined attribute of metric states.
 
 from collections import defaultdict, deque
-from typing import Iterable, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import torch
 
@@ -17,9 +17,11 @@ TDummySumMetric = TypeVar("TDummySumMetric")
 
 
 class DummySumMetric(Metric[torch.Tensor]):
-    def __init__(self: TDummySumMetric) -> None:
-        super().__init__()
-        self._add_state("sum", torch.tensor(0.0))
+    def __init__(
+        self: TDummySumMetric, *, device: Optional[torch.device] = None
+    ) -> None:
+        super().__init__(device=device)
+        self._add_state("sum", torch.tensor(0.0, device=self.device))
 
     @torch.inference_mode()
     # pyre-ignore[14]: inconsistent override on *_:Any, **__:Any
@@ -44,8 +46,10 @@ TDummySumListStateMetric = TypeVar("TDummySumListStateMetric")
 
 
 class DummySumListStateMetric(Metric[torch.Tensor]):
-    def __init__(self: TDummySumListStateMetric) -> None:
-        super().__init__()
+    def __init__(
+        self: TDummySumListStateMetric, *, device: Optional[torch.device] = None
+    ) -> None:
+        super().__init__(device=device)
         self._add_state("x", [])
 
     @torch.inference_mode()
@@ -74,8 +78,10 @@ TDummySumDictStateMetric = TypeVar("TDummySumDictStateMetric")
 
 
 class DummySumDictStateMetric(Metric[torch.Tensor]):
-    def __init__(self: TDummySumDictStateMetric) -> None:
-        super().__init__()
+    def __init__(
+        self: TDummySumDictStateMetric, *, device: Optional[torch.device] = None
+    ) -> None:
+        super().__init__(device=device)
         self._add_state("x", defaultdict(lambda: torch.tensor(0.0, device=self.device)))
 
     @torch.inference_mode()
@@ -107,8 +113,10 @@ TDummySumDequeStateMetric = TypeVar("TDummySumDequeStateMetric")
 
 
 class DummySumDequeStateMetric(Metric[torch.Tensor]):
-    def __init__(self: TDummySumDequeStateMetric) -> None:
-        super().__init__()
+    def __init__(
+        self: TDummySumDequeStateMetric, *, device: Optional[torch.device] = None
+    ) -> None:
+        super().__init__(device=device)
         self._add_state("x", deque())
 
     @torch.inference_mode()
@@ -116,7 +124,7 @@ class DummySumDequeStateMetric(Metric[torch.Tensor]):
     def update(
         self: TDummySumDequeStateMetric, x: torch.Tensor
     ) -> TDummySumDequeStateMetric:
-        self.x.append(x)
+        self.x.append(x.to(self.device))
         return self
 
     @torch.inference_mode()


### PR DESCRIPTION
Summary:
This is informally recommended in our docs for metric usage, but it's not yet strictly enforced. This is a breaking change for users of these metrics who are passing arguments positionally. it is intended to:
- encourage more readable code for users (ie. metric.update(input, target, weight=weight) vs metric.update(input, target, 2.0)
- reduce the risk of breaking changes later, in case for any reason we change the argument order which have default values

Differential Revision: D38679678

