### PR TITLE
Reassign maxlen value to deque when moving to another device

### DIFF
--- a/torcheval/metrics/metric.py
+++ b/torcheval/metrics/metric.py
@@ -257,7 +257,10 @@ class Metric(Generic[TComputeReturn], ABC):
                 setattr(
                     self,
                     state_name,
-                    deque([tensor.to(device, *args, **kwargs) for tensor in value]),
+                    deque(
+                        [tensor.to(device, *args, **kwargs) for tensor in value],
+                        maxlen=value.maxlen,
+                    ),
                 )
         self._device = device
         return self


### PR DESCRIPTION
Summary: Based on D38591082 (https://github.com/pytorch-labs/torcheval/commit/bb3373e92e19445f0ecc13d3237b6d0b3ccdc083), we should reassign maxlen value to deque when moving to another device.

Differential Revision: D38772106

