### PR TITLE
Bump version after breaking changes

### DIFF
--- a/torcheval/version.py
+++ b/torcheval/version.py
@@ -14,4 +14,4 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__: str = "0.0.3"
+__version__: str = "0.0.4"


### PR DESCRIPTION
Summary: Bump the package version after https://github.com/pytorch-labs/torcheval/pull/13 to minimize the number of users who are on a version of the library that will have breaking changes after

Reviewed By: tangbinh

Differential Revision: D38680352

