### PR TITLE
Add imports to tools/__init__.py for convenience

### DIFF
--- a/torcheval/tools/__init__.py
+++ b/torcheval/tools/__init__.py
@@ -3,3 +3,17 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from torcheval.tools.module_summary import (
+    get_module_summary,
+    get_summary_table,
+    ModuleSummary,
+    prune_module_summary,
+)
+
+__all__ = [
+    "get_module_summary",
+    "get_summary_table",
+    "ModuleSummary",
+    "prune_module_summary",
+]


### PR DESCRIPTION
Summary:
As title, this lets users do this instead:
```
from torcheval.tools import get_module_summary
```

vs
```
from torcheval.tools.module_summary import get_module_summary
```

Differential Revision: D39195816

