### PR TITLE
Add FBGEMM_GPU's AUC op to BinaryAUROC

### DIFF
--- a/tests/metrics/classification/test_auroc.py
+++ b/tests/metrics/classification/test_auroc.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-ignore-all-errors[56]: Pyre was not able to infer the type of argument
+
+import unittest
 from typing import Optional
 
 import torch
@@ -25,6 +28,7 @@ class TestBinaryAUROC(MetricClassTester):
         target: torch.Tensor,
         num_tasks: int = 1,
         compute_result: Optional[torch.Tensor] = None,
+        use_fbgemm: Optional[bool] = False,
     ) -> None:
         input_tensors = input.reshape(-1, 1)
         target_tensors = target.reshape(-1, 1)
@@ -32,26 +36,32 @@ class TestBinaryAUROC(MetricClassTester):
             compute_result = torch.tensor(roc_auc_score(target_tensors, input_tensors))
 
         self.run_class_implementation_tests(
-            metric=BinaryAUROC(num_tasks=num_tasks),
+            metric=BinaryAUROC(num_tasks=num_tasks, use_fbgemm=use_fbgemm),
             state_names={"inputs", "targets"},
             update_kwargs={
                 "input": input,
                 "target": target,
             },
             compute_result=compute_result,
+            test_devices=["cuda"] if use_fbgemm else None,
         )
 
-    def test_auroc_class_base(self) -> None:
+    def _test_auroc_class_set(self, use_fbgemm: Optional[bool] = False) -> None:
         input = torch.rand(NUM_TOTAL_UPDATES, BATCH_SIZE)
         target = torch.randint(high=2, size=(NUM_TOTAL_UPDATES, BATCH_SIZE))
-        self._test_auroc_class_with_input(input, target)
+        self._test_auroc_class_with_input(input, target, use_fbgemm=use_fbgemm)
 
-        input = torch.randint(high=2, size=(NUM_TOTAL_UPDATES, BATCH_SIZE))
-        target = torch.randint(high=2, size=(NUM_TOTAL_UPDATES, BATCH_SIZE))
-        self._test_auroc_class_with_input(
-            input,
-            target,
-        )
+        if not use_fbgemm:
+            # Skip this test for use_fbgemm because FBGEMM AUC is an
+            # approximation of AUC. It can give a significantly different
+            # result if input data is highly redundant
+            input = torch.randint(high=2, size=(NUM_TOTAL_UPDATES, BATCH_SIZE))
+            target = torch.randint(high=2, size=(NUM_TOTAL_UPDATES, BATCH_SIZE))
+            self._test_auroc_class_with_input(
+                input,
+                target,
+                use_fbgemm=use_fbgemm,
+            )
 
         num_tasks = 2
         torch.manual_seed(123)
@@ -64,7 +74,17 @@ class TestBinaryAUROC(MetricClassTester):
             compute_result=torch.tensor(
                 [0.549048678033111, 0.512218963831867], dtype=torch.float64
             ),
+            use_fbgemm=use_fbgemm,
         )
+
+    @unittest.skipUnless(
+        condition=torch.cuda.is_available(), reason="This test needs a GPU host to run."
+    )
+    def test_auroc_class_fbgemm(self) -> None:
+        self._test_auroc_class_set(use_fbgemm=True)
+
+    def test_auroc_class_base(self) -> None:
+        self._test_auroc_class_set(use_fbgemm=False)
 
     def test_auroc_class_update_input_shape_different(self) -> None:
         num_classes = 2

--- a/torcheval/utils/test_utils/metric_class_tester.py
+++ b/torcheval/utils/test_utils/metric_class_tester.py
@@ -11,7 +11,7 @@ import uuid
 from copy import deepcopy
 from dataclasses import dataclass
 from socket import socket
-from typing import Any, Dict, List, Sequence, Set
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 import torch
 import torch.distributed.launcher as pet
@@ -61,6 +61,7 @@ class MetricClassTester(unittest.TestCase):
         num_processes: int = NUM_PROCESSES,
         atol: float = 1e-8,
         rtol: float = 1e-5,
+        test_devices: Optional[List[str]] = None,
     ) -> None:
         """
         Run a test case to verify metric class implementations.
@@ -85,6 +86,8 @@ class MetricClassTester(unittest.TestCase):
                 ``num_processes``.
             atol: Absolute tolerance used in ``torch.testing.assert_close``
             rtol: Relative tolerance used in ``torch.testing.assert_close``
+            test_devices: List of test devices. If None, will be determined
+                automatically.
         """
         # update args and state names should not be empty
         self.assertTrue(update_kwargs)
@@ -116,7 +119,9 @@ class MetricClassTester(unittest.TestCase):
             rtol,
         )
 
-        test_devices = ("cpu", "cuda") if torch.cuda.is_available() else ("cpu",)
+        if test_devices is None:
+            test_devices = ("cpu", "cuda") if torch.cuda.is_available() else ("cpu",)
+
         for device in test_devices:
             self._test_case_spec.device = device
             self._test_case_spec = copy_data_to_device(


### PR DESCRIPTION
Summary:
Adopt FBGEMM_GPU's fused batch AUC in BinaryAUROC.  It can be
enabled/disabled via the `use_fbgemm` argument.

FBGEMM AUC is an approximation of AUC.  It does not mask data if the
input data is redundant.  For the case where input data is highly
redundant, FBGEMM AUC can give a significantly different result.

Differential Revision: D39090884

