### PR TITLE
fix the bug in multi-task version of AUROC

### DIFF
--- a/tests/metrics/functional/classification/test_auroc.py
+++ b/tests/metrics/functional/classification/test_auroc.py
@@ -55,12 +55,12 @@ class TestBinaryAUROC(unittest.TestCase):
         self._test_auroc_with_input(input, target, use_fbgemm=use_fbgemm)
 
         input = torch.tensor([[1, 1, 1, 0], [0.1, 0.5, 0.7, 0.8]])
-        target = torch.tensor([[1, 0, 1, 0], [1, 0, 1, 1]])
+        target = torch.tensor([[1, 0, 1, 0], [1, 0, 1, 0]])
         self._test_auroc_with_input(
             input,
             target,
             2,
-            torch.tensor([0.7500, 0.6666666666666666], dtype=torch.float64),
+            torch.tensor([0.7500, 0.2500], dtype=torch.float64),
             use_fbgemm=use_fbgemm,
         )
 


### PR DESCRIPTION
Summary:
As title.
Previous multi-task version of AUROC introduced a bug:
Number of Non-zero values in the mask vary cross the rows, which makes padding ahead of each row naively leading to wrong output.

For example,
```
input = torch.tensor([[0, 0.8, 0.9, 0, 1, 0.2, 0, 1, 0.5, 1], [0, 1, 0, 1, 0, 0, 1, 0, 0, 1]])
target = torch.tensor([[1, 0, 0, 1, 0, 0, 1, 1, 1, 1],[0, 1, 1, 1, 1, 0, 1, 1, 1, 1] ])
>>> mask=tensor([[0, 0, 1, 1, 1, 1, 1, 0, 0, 1], [0, 0, 0, 1, 0, 0, 0, 0, 0, 1]], dtype=torch.int32)
output = auroc_compute(input, target)
>>> tensor([0.5833, 0.5000], dtype=torch.float64)
```

However, what we need is
```
>>> tensor([0.3333, 0.7500], dtype=torch.float64)
```

This diff aims to fix this issue.

Reviewed By: tangbinh

Differential Revision: D39406659

